### PR TITLE
Fixed bug in GetSpeciesDistributions

### DIFF
--- a/Rcode_scripts/worms_safe.R
+++ b/Rcode_scripts/worms_safe.R
@@ -533,12 +533,23 @@ fromJSONsafe <- function(url, max_attempts=3){
         return(result)
       },
       error=function(e) {
-        message('fromJSON returned an error')
-        print(e)
+        if(stringr::str_detect(e$message,"parse error: premature EOF")){
+          #' this occurs when retrieving distributions and we go past the end of records
+          i <- max_attempts
+        }else{
+          message('fromJSON returned an error')
+          print(e)
+        }
       },
       warning=function(w) {
-        message('fromJSON returned an warning')
-        print(w)
+        if(stringr::str_detect(w$message,"status was 'Couldn't resolve host name'")){
+          #' this occurs when calling https://marinespecies.org/rest/AphiaDistributionsByAphiaID 
+          #' and there are no distribution records at all
+          i <- max_attempts
+        }else{
+          message('fromJSON returned an warning')
+          print(w)
+        }
       },
       finally = {
         Sys.sleep(1)

--- a/Rcode_scripts/worms_safe.R
+++ b/Rcode_scripts/worms_safe.R
@@ -308,7 +308,6 @@ GetSpeciesDistributions<-function(AphiaID){
     cat(paste0("  No synonyms found\n"))
     bSynonyms = FALSE
   }
-  
   # ---------- Get all distributions for a given AphiaID -----------------------------------------------
   
   # loop through AphiaID for synonyms
@@ -369,7 +368,7 @@ GetSpeciesDistributions<-function(AphiaID){
     }
   }
   
-  if(!exists("distribution")){
+  if(bFoundDistribution==FALSE){
     
     # check for null values in the record
     if(is.null(AphiaRecord$kingdom)){


### PR DESCRIPTION
Fixed bug in GetSpeciesDistributions(). The case where no distributions at all were returned for AphiaID or any synonyms was not handled correctly, causing an error
Also modified fromJSON(). There is no need to echo an error message or repeat attempts to retrieve data if the error is known and handled.